### PR TITLE
Improve entity-button card input_boolean support

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -209,6 +209,10 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
         color: var(--paper-item-icon-active-color, #fdd835);
       }
 
+      ha-icon[data-domain="input_boolean"][data-state="on"] {
+        color: var(--paper-item-icon-active-non-electric-or-sun-color, #34befc);
+      }
+
       ha-icon[data-state="unavailable"] {
         color: var(--state-icon-unavailable-color);
       }


### PR DESCRIPTION
Entity button cards are completely broken with input_boolean entities. If yellow is already reserved for electricity and implicitly yellow things (like bananas) there needs to be a non-electric active color for non-electric things that can be active. If yellow is really off limits, a simple fix like this would easily save thousands of hours of frustration.

What's really driving me up the wall is the fact that I'm trying to indirectly make a smart plug switch 1½ kW load on and off. My next option would be to implement a custom switch platform called `switchput_boolean` or something.